### PR TITLE
Don't explicitly represent x0 in sigcontext etc.

### DIFF
--- a/arch/riscv/include/asm/ptrace.h
+++ b/arch/riscv/include/asm/ptrace.h
@@ -6,7 +6,7 @@
 #ifndef __ASSEMBLY__
 
 typedef struct pt_regs {
-	unsigned long zero;
+	unsigned long epc;
 	unsigned long ra;
 	unsigned long s[12];
 	unsigned long sp;
@@ -17,7 +17,6 @@ typedef struct pt_regs {
 	unsigned long gp;
 	/* PCRs */
 	unsigned long status;
-	unsigned long epc;
 	unsigned long badvaddr;
 	unsigned long cause;
 	/* For restarting system calls */

--- a/arch/riscv/include/asm/sigcontext.h
+++ b/arch/riscv/include/asm/sigcontext.h
@@ -6,7 +6,7 @@
  */
 
 struct sigcontext {
-	unsigned long zero;
+	unsigned long epc;
 	unsigned long ra;
 	unsigned long s[12];
 	unsigned long sp;
@@ -15,7 +15,6 @@ struct sigcontext {
 	unsigned long a[8];
 	unsigned long t[5];
 	unsigned long gp;
-	unsigned long epc;
 };
 
 #endif /* __ASM_RISCV_SIGCONTEXT_H */

--- a/arch/riscv/include/asm/user.h
+++ b/arch/riscv/include/asm/user.h
@@ -4,7 +4,7 @@
 /* Mirror pt_regs from ptrace.h */
 
 typedef struct user_regs_struct {
-	unsigned long zero;
+	unsigned long pc;
 	unsigned long ra;
 	unsigned long s[12];
 	unsigned long sp;

--- a/arch/riscv/kernel/asm-offsets.c
+++ b/arch/riscv/kernel/asm-offsets.c
@@ -23,7 +23,7 @@ void asm_offsets(void)
 	OFFSET(TI_FLAGS, thread_info, flags);
 
 	DEFINE(PT_SIZE, sizeof(struct pt_regs));
-	OFFSET(PT_ZERO, pt_regs, zero);
+	OFFSET(PT_EPC, pt_regs, epc);
 	OFFSET(PT_RA, pt_regs, ra);
 	OFFSET(PT_FP, pt_regs, s[0]);
 	OFFSET(PT_S0, pt_regs, s[0]);
@@ -57,7 +57,6 @@ void asm_offsets(void)
 	OFFSET(PT_T4, pt_regs, t[4]);
 	OFFSET(PT_GP, pt_regs, gp);
 	OFFSET(PT_STATUS, pt_regs, status);
-	OFFSET(PT_EPC, pt_regs, epc);
 	OFFSET(PT_BADVADDR, pt_regs, badvaddr);
 	OFFSET(PT_CAUSE, pt_regs, cause);
 	OFFSET(PT_SYSCALLNO, pt_regs, syscallno);

--- a/arch/riscv/kernel/process.c
+++ b/arch/riscv/kernel/process.c
@@ -26,8 +26,8 @@ void show_regs(struct pt_regs *regs)
 {
 	show_regs_print_info(KERN_DEFAULT);
 
-	printk("x0 : %016lx ra : %016lx s0 : %016lx\n",
-		regs->zero, regs->ra, regs->s[0]);
+	printk("epc: %016lx ra : %016lx s0 : %016lx\n",
+		regs->epc, regs->ra, regs->s[0]);
 	printk("s1 : %016lx s2 : %016lx s3 : %016lx\n",
 		regs->s[1], regs->s[2], regs->s[3]);
 	printk("s4 : %016lx s5 : %016lx s6 : %016lx\n",
@@ -49,9 +49,8 @@ void show_regs(struct pt_regs *regs)
 	printk("t4 : %016lx gp : %016lx\n",
 		regs->t[4], regs->gp);
 
-	printk("status  : %016lx epc  : %016lx\n"
-		"badvaddr: %016lx cause: %016lx\n",
-		regs->status, regs->epc, regs->badvaddr, regs->cause);
+	printk("status: %016lx badvaddr: %016lx cause: %016lx\n",
+		regs->status, regs->badvaddr, regs->cause);
 }
 
 void start_thread(struct pt_regs *regs, unsigned long pc, 

--- a/arch/riscv/kernel/signal.c
+++ b/arch/riscv/kernel/signal.c
@@ -21,7 +21,7 @@ static int restore_sigcontext(struct pt_regs *regs,
 	int err = 0;
 	unsigned int i;
 
-	err |= __get_user(regs->zero, &sc->zero);
+	err |= __get_user(regs->epc, &sc->epc);
 	err |= __get_user(regs->ra, &sc->ra);
 	for (i = 0; i < (sizeof(regs->s) / sizeof(unsigned long)); i++) {
 		err |= __get_user(regs->s[i], &sc->s[i]);
@@ -38,8 +38,6 @@ static int restore_sigcontext(struct pt_regs *regs,
 		err |= __get_user(regs->t[i], &sc->t[i]);
 	}
 	err |= __get_user(regs->gp, &sc->gp);
-
-	err |= __get_user(regs->epc, &sc->epc);
 
 	/* Disable sys_rt_sigreturn() restarting */
 	regs->syscallno = ~0UL;
@@ -92,7 +90,7 @@ static int setup_sigcontext(struct sigcontext __user *sc,
 	int err = 0;
 	unsigned int i;
 
-	err |= __put_user(regs->zero, &sc->zero);
+	err |= __put_user(regs->epc, &sc->epc);
 	err |= __put_user(regs->ra, &sc->ra);
 	for (i = 0; i < (sizeof(regs->s) / sizeof(unsigned long)); i++) {
 		err |= __put_user(regs->s[i], &sc->s[i]);
@@ -110,7 +108,6 @@ static int setup_sigcontext(struct sigcontext __user *sc,
 	}
 	err |= __put_user(regs->gp, &sc->gp);
 
-	err |= __put_user(regs->epc, &sc->epc);
 	return err;
 }
 


### PR DESCRIPTION
Move epc into that slot instead.
