### PR TITLE
riscv: Improve atomic memory access and support -mno-atomic.

### DIFF
--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -9,6 +9,9 @@ config RISCV
 	select CLONE_BACKWARDS
 	select GENERIC_STRNCPY_FROM_USER
 	select GENERIC_STRNLEN_USER
+	select GENERIC_ATOMIC64 if !64BIT || !RV_ATOMIC
+	select RV_ATOMIC if SMP
+	select RV_SYSRISCV_ATOMIC if !RV_ATOMIC
 
 config MMU
 	def_bool y
@@ -46,6 +49,22 @@ config CPU_SUPPORTS_32BIT_KERNEL
 	bool
 config CPU_SUPPORTS_64BIT_KERNEL
 	bool
+
+config RV_ATOMIC
+	bool "Use atomic memory instructions (RV32A or RV64A)"
+	default y
+
+config RV_SYSRISCV_ATOMIC
+	bool "Include support for atomic operation syscalls"
+	default n
+	help
+	 If atomic memory instructions are present, i.e.,
+	 CONFIG_RV_ATOMIC, this includes support for the syscall that
+	 provides atomic accesses.  This is only useful to run
+	 binaries that require atomic access but were compiled with
+	 -mno-atomic.
+
+	 If CONFIG_RV_ATOMIC is unset, this option is mandatory.
 
 menuconfig HTIF
 	bool "HTIF"

--- a/arch/riscv/Makefile
+++ b/arch/riscv/Makefile
@@ -30,6 +30,10 @@ else
 	KBUILD_CFLAGS += -m32
 endif
 
+ifeq ($(CONFIG_RV_ATOMIC),)
+KBUILD_CFLAGS += -mno-atomic
+endif
+
 KBUILD_CFLAGS += -Wall
 KBUILD_CFLAGS += -fno-section-anchors
 

--- a/arch/riscv/include/asm/Kbuild
+++ b/arch/riscv/include/asm/Kbuild
@@ -55,7 +55,6 @@ generic-y += stat.h
 generic-y += statfs.h
 generic-y += swab.h
 generic-y += switch_to.h
-generic-y += syscalls.h
 generic-y += termbits.h
 generic-y += termios.h
 generic-y += topology.h

--- a/arch/riscv/include/asm/atomic.h
+++ b/arch/riscv/include/asm/atomic.h
@@ -1,6 +1,8 @@
 #ifndef _ASM_RISCV_ATOMIC_H
 #define _ASM_RISCV_ATOMIC_H
 
+#ifdef CONFIG_RV_ATOMIC
+
 #include <asm/cmpxchg.h>
 #include <asm/barrier.h>
 
@@ -272,6 +274,12 @@ static inline void atomic_set_mask(unsigned int mask, atomic_t *v)
 #define smp_mb__after_atomic_dec()	barrier()
 #define smp_mb__before_atomic_inc()	barrier()
 #define smp_mb__after_atomic_inc()	barrier()
+
+#else /* !CONFIG_RV_ATOMIC */
+
+#include <asm-generic/atomic.h>
+
+#endif /* CONFIG_RV_ATOMIC */
 
 #include <asm/atomic64.h>
 

--- a/arch/riscv/include/asm/atomic64.h
+++ b/arch/riscv/include/asm/atomic64.h
@@ -3,9 +3,7 @@
 
 #include <linux/types.h>
 
-#ifdef CONFIG_32BIT
-#error "RV64A instruction set extension required"
-#endif /* CONFIG_32BIT */
+#ifndef CONFIG_GENERIC_ATOMIC64
 
 #define ATOMIC64_INIT(i)	{ (i) }
 
@@ -271,5 +269,7 @@ static inline int atomic64_inc_not_zero(atomic64_t *v)
 		: "memory");
 	return !rc;
 }
+
+#endif /* CONFIG_GENERIC_ATOMIC64 */
 
 #endif /* _ASM_RISCV_ATOMIC64_H */

--- a/arch/riscv/include/asm/bitops.h
+++ b/arch/riscv/include/asm/bitops.h
@@ -12,6 +12,8 @@
 #include <asm/barrier.h>
 #include <asm/bitsperlong.h>
 
+#ifdef CONFIG_RV_ATOMIC
+
 #define LONG_MASK(nr) (1UL << ((nr) & (BITS_PER_LONG - 1)))
 #ifdef CONFIG_64BIT
 #define LONG_WORD(nr) ((nr) >> 6)
@@ -272,5 +274,12 @@ static inline void __clear_bit_unlock(
 #include <asm-generic/bitops/le.h>
 #include <asm-generic/bitops/ext2-atomic.h>
 
+#else /* !CONFIG_RV_ATOMIC */
+
+#include <asm-generic/bitops.h>
+
+#endif /* CONFIG_RV_ATOMIC */
+
 #endif /* __KERNEL__ */
+
 #endif /* _ASM_RISCV_BITOPS_H */

--- a/arch/riscv/include/asm/cmpxchg.h
+++ b/arch/riscv/include/asm/cmpxchg.h
@@ -3,6 +3,8 @@
 
 #include <linux/bug.h>
 
+#ifdef CONFIG_RV_ATOMIC
+
 #include <asm/barrier.h>
 
 #define __xchg(new, ptr, size)					\
@@ -103,5 +105,11 @@
 	BUILD_BUG_ON(sizeof(*(ptr)) != 8);	\
 	cmpxchg_local((ptr), (o), (n));		\
 })
+
+#else /* !CONFIG_RV_ATOMIC */
+
+#include <asm-generic/cmpxchg.h>
+
+#endif /* CONFIG_RV_ATOMIC */
 
 #endif /* _ASM_RISCV_CMPXCHG_H */

--- a/arch/riscv/include/asm/syscalls.h
+++ b/arch/riscv/include/asm/syscalls.h
@@ -1,0 +1,13 @@
+#ifndef _ASM_RISCV_SYSCALLS_H
+#define _ASM_RISCV_SYSCALLS_H
+
+#include <linux/compiler.h>
+#include <linux/linkage.h>
+#include <linux/types.h>
+#include <asm-generic/syscalls.h>
+
+/* kernel/sys_riscv.c */
+asmlinkage long sys_sysriscv(unsigned long, unsigned long, unsigned long,
+	unsigned long);
+
+#endif

--- a/arch/riscv/include/asm/unistd.h
+++ b/arch/riscv/include/asm/unistd.h
@@ -14,8 +14,16 @@
 
 #include <asm-generic/unistd.h>
 
+#define __NR_sysriscv  __NR_arch_specific_syscall
+#ifdef CONFIG_RV_SYSRISCV_ATOMIC
+__SYSCALL(__NR_sysriscv, sys_sysriscv)
+#endif
+
 #define __NR_ipc 1080
 #undef  __NR_syscalls
 #define __NR_syscalls (__NR_ipc + 1)
+
+#define RISCV_ATOMIC_CMPXCHG    1
+#define RISCV_ATOMIC_CMPXCHG64  2
 
 #endif /* _ASM_RISCV_UNISTD_H */

--- a/arch/riscv/kernel/sys_riscv.c
+++ b/arch/riscv/kernel/sys_riscv.c
@@ -1,4 +1,5 @@
 #include <linux/syscalls.h>
+#include <asm/unistd.h>
 
 SYSCALL_DEFINE6(mmap, unsigned long, addr, unsigned long, len,
 	unsigned long, prot, unsigned long, flags,
@@ -9,3 +10,50 @@ SYSCALL_DEFINE6(mmap, unsigned long, addr, unsigned long, len,
 	return sys_mmap_pgoff(addr, len, prot, flags, fd, offset >> PAGE_SHIFT);
 }
 
+#ifdef CONFIG_RV_SYSRISCV_ATOMIC
+SYSCALL_DEFINE4(sysriscv, unsigned long, cmd, unsigned long, arg1,
+	unsigned long, arg2, unsigned long, arg3)
+{
+	unsigned long flags;
+	unsigned long prev;
+	unsigned int err;
+
+	switch (cmd) {
+	case RISCV_ATOMIC_CMPXCHG:
+		if (unlikely(!access_ok(VERIFY_WRITE, arg1, sizeof(unsigned int))))
+			return -EINVAL;
+
+		preempt_disable();
+		raw_local_irq_save(flags);
+		err = __get_user(prev, (unsigned int *)arg1);
+		if (prev == arg2)
+			err |= __put_user(arg3, (unsigned int *)arg1);
+		raw_local_irq_restore(flags);
+		preempt_enable();
+
+		if (unlikely(err))
+			return -EFAULT;
+
+		return prev;
+
+	case RISCV_ATOMIC_CMPXCHG64:
+		if (unlikely(!access_ok(VERIFY_WRITE, arg1, sizeof(unsigned long))))
+			return -EINVAL;
+
+		preempt_disable();
+		raw_local_irq_save(flags);
+		err = __get_user(prev, (unsigned long *)arg1);
+		if (prev == arg2)
+			err |= __put_user(arg3, (unsigned long *)arg1);
+		raw_local_irq_restore(flags);
+		preempt_enable();
+
+		if (unlikely(err))
+			return -EFAULT;
+
+		return prev;
+	}
+
+	return -EINVAL;
+}
+#endif /* CONFIG_RV_SYSRISCV_ATOMIC */


### PR DESCRIPTION
Use CONFIG_GENERIC_ATOMIC64 if 32-bit.  Add system call to emulate
atomic compare exchange, primarily for targets lacking hardware
suport (i.e., lacking RV32A, RV64A).  Support excluding use of
atomic memory instructions (-mno-atomic).

This change is mutually dependent on the corresponding change to
riscv-gcc.

This change is also dependent on three patches outside of
arch/riscv/ which have been submitted upstream.
