### PR TITLE
riscv/Makefile: Add linker output format to LDFLAGS.

### DIFF
--- a/arch/riscv/Makefile
+++ b/arch/riscv/Makefile
@@ -26,10 +26,12 @@ ifeq ($(CONFIG_64BIT),y)
 	BITS := 64
 	KBUILD_CFLAGS += -m64
 	KBUILD_AFLAGS += -m64
+	LDFLAGS += -melf64lriscv
 else
 	BITS := 32
 	KBUILD_CFLAGS += -m32
 	KBUILD_AFLAGS += -m32
+	LDFLAGS += -melf32lriscv
 endif
 
 ifeq ($(CONFIG_RV_ATOMIC),)


### PR DESCRIPTION
Specify linker output format, in case it differs from the toolchain
default.  This happens, for example, when compling a kernel for
32-bit (with -m32) with tools that default to 64-bit.