### PR TITLE
Rework usage of scratch registers

### DIFF
--- a/arch/riscv/include/asm/current.h
+++ b/arch/riscv/include/asm/current.h
@@ -7,7 +7,8 @@ struct task_struct;
 
 static inline struct task_struct *get_current(void)
 {
-	return (struct task_struct *)(csr_read(sup0));
+	register struct task_struct * tp asm("tp");
+	return tp;
 }
 
 #define current (get_current())

--- a/arch/riscv/kernel/entry.S
+++ b/arch/riscv/kernel/entry.S
@@ -12,21 +12,14 @@
 	LOCAL _restore_kernel_sp
 	LOCAL _save_context
 
-	/* Save stack pointer */
-	csrw sup1, sp
-	/* Check if originated from user mode */
-	csrr sp, status
-	andi sp, sp, SR_PS
-	bnez sp, _restore_kernel_sp
-
-	/* Switch to kernel mode stack; load stack
-	   pointer from current->thread.sp */
-	csrr sp, sup0
-	REG_L sp, THREAD_SP(sp)
-	j _save_context
+	/* If coming from userspace, preserve the user stack pointer and
+	   load the kernel stack pointer.  If we came from the kernel, sup0
+	   will contain 0, and we should continue on the current stack. */
+	csrrw sp, sup0, sp
+	bnez sp, _save_context
 
 _restore_kernel_sp:
-	csrr sp, sup1
+	csrr sp, sup0
 _save_context:
 	addi sp, sp, -(PT_SIZE)
 	REG_S x1,  PT_RA(sp)
@@ -60,7 +53,7 @@ _save_context:
 	REG_S x30, PT_T5(sp)
 	REG_S x31, PT_T6(sp)
 
-	csrr s0, sup1
+	csrr s0, sup0
 	csrr s1, status
 	csrr s2, epc
 	csrr s3, badvaddr
@@ -77,19 +70,12 @@ _save_context:
 	REG_L a0, PT_STATUS(sp)
 	li s0, ~(SR_IM | SR_EI)
 	REG_L a2, PT_EPC(sp)
-	csrr a3, sup0
 	li s1, (SR_IM)
 	and a0, a0, s0
 	and a1, a1, s1
 	/* Retain current IM field */
 	or a0, a0, a1
 	csrw status, a0
-
-	/* Save unwound kernel stack pointer
-	   into current->thread.sp */
-	addi s0, sp, PT_SIZE
-	REG_S s0, THREAD_SP(a3)
-
 	csrw epc, a2
 
 	REG_L x1,  PT_RA(sp)
@@ -128,6 +114,17 @@ _save_context:
 
 ENTRY(handle_exception)
 	SAVE_ALL
+
+	/* Set sup0 scratch register to 0, so that if a recursive exception
+	   occurs, the exception vector knows it came from the kernel */
+	csrw sup0, x0
+
+	/* Compute address of current thread_info */
+	li tp, ~(THREAD_SIZE-1)
+	and tp, tp, sp
+	/* Set the current thread pointer */
+	REG_L tp, 0(tp)
+
 	csrr s0, cause
 	la gp, _gp
 	la ra, ret_from_exception
@@ -189,12 +186,14 @@ ret_from_exception:
 resume_userspace:
 	csrc status, SR_EI /* Disable interrupts to ensure that thread
 	                      info flags are checked atomically */
-	csrr s0, sup0
-	REG_L s0, TASK_THREAD_INFO(s0)
+	REG_L s0, TASK_THREAD_INFO(tp)
 	REG_L s0, TI_FLAGS(s0) /* current_thread_info->flags */
 	andi s1, s0, _TIF_WORK_MASK
 	bnez s1, work_pending
 
+	/* Save unwound kernel stack pointer in sup0 */
+	addi s0, sp, PT_SIZE
+	csrw sup0, s0
 restore_all:
 	RESTORE_ALL
 	sret
@@ -217,14 +216,14 @@ END(handle_exception)
 
 
 ENTRY(ret_from_fork)
-	la ra, restore_all
+	la ra, ret_from_exception
 	tail schedule_tail
 ENDPROC(ret_from_fork)
 
 ENTRY(ret_from_kernel_thread)
 	call schedule_tail
 	/* Call fn(arg) */
-	la ra, restore_all
+	la ra, ret_from_exception
 	move a0, s1
 	jr s0
 ENDPROC(ret_from_kernel_thread)
@@ -268,7 +267,7 @@ ENTRY(__switch_to)
 	REG_L s10, THREAD_S10(a1)
 	REG_L s11, THREAD_S11(a1)
 	REG_L sp,  THREAD_SP(a1)
-	csrw sup0, a1 /* Next current pointer */
+	mv tp, a1 /* Next current pointer */
 	ret
 ENDPROC(__switch_to)
 

--- a/arch/riscv/kernel/head.S
+++ b/arch/riscv/kernel/head.S
@@ -109,9 +109,8 @@ ENTRY(_start)
 
 	/* Initialize stack pointer */
 	la sp, init_thread_union + THREAD_SIZE
-	/* Initialize current thread_struct pointer */
-	la s0, init_task
-	csrw sup0, s0
+	/* Initialize current task_struct pointer */
+	la tp, init_task
 
 	tail start_kernel
 

--- a/arch/riscv/kernel/traps.c
+++ b/arch/riscv/kernel/traps.c
@@ -147,6 +147,9 @@ void __init trap_init(void)
 {
 	/* Clear the IPI exception that started the processor */
 	csr_write(clear_ipi, 0);
+	/* Set sup0 scratch register to 0, indicating to exception vector
+	   that we are presently executing in the kernel */
+	csr_write(sup0, 0);
 	/* Set the exception vector address */
 	csr_write(evec, &handle_exception);
 }


### PR DESCRIPTION
In the new supervisor spec, we will have only one supervisor scratch
register.  (Why?  Because this commit proves it's possible.)  In
preparation for that, I got rid of all uses of the second scratch register.

To do this efficiently required reworking the sup0 discipline.  Previously,
it contained a pointer to the current task_struct.  Now, it contains the
stack pointer to use on kernel entry.  (The task_struct pointer can be
computed using the stack pointer, so nothing is lost.)

However, we used to need sup1 as a scratch register so the trap vector
could read the status register to determine whether the trap came from
userspace or from the kernel.  To accomplish that, I changed the sup0
discipline further: it's now always 0 while executing in the kernel,
instead of containing the kernel stack pointer.  That way, the act of
setting up the kernel stack on trap entry also has the side effect of
making it easy to tell whether the trap came from userspace.

End-to-end, the kernel entry/exit path is actually 3 instructions shorter,
including the removal of a store.

To keep regular access to task_struct fast, we now keep that pointer in the
tp register, which previously had been altogether unused by the kernel.
Avoiding all those sup0 accesses reduces code size by 0.5%!