### PR TITLE
Add "-mno-save-restore" to riscv-linux

### DIFF
--- a/arch/riscv/Makefile
+++ b/arch/riscv/Makefile
@@ -46,6 +46,8 @@ ifeq ($(CONFIG_RVC),y)
 	KBUILD_AFLAGS += -Wa,-mrvc
 endif
 
+KBUILD_CFLAGS += -mno-save-restore
+
 head-y := arch/riscv/kernel/head.o
 
 core-y += arch/riscv/kernel/ arch/riscv/mm/


### PR DESCRIPTION
This disables GCC's compressed register save/restore blocks, which are
used to make function entry/exit smaller.  Enabling this requires
library support, which doesn't happen in Linux.