### PR TITLE
Generic changes necessary for RV64 and no-atomic.

### DIFF
--- a/include/asm-generic/cmpxchg-local.h
+++ b/include/asm-generic/cmpxchg-local.h
@@ -24,19 +24,19 @@ static inline unsigned long __cmpxchg_local_generic(volatile void *ptr,
 	raw_local_irq_save(flags);
 	switch (size) {
 	case 1: prev = *(u8 *)ptr;
-		if (prev == old)
+		if (prev == (u8)old)
 			*(u8 *)ptr = (u8)new;
 		break;
 	case 2: prev = *(u16 *)ptr;
-		if (prev == old)
+		if (prev == (u16)old)
 			*(u16 *)ptr = (u16)new;
 		break;
 	case 4: prev = *(u32 *)ptr;
-		if (prev == old)
+		if (prev == (u32)old)
 			*(u32 *)ptr = (u32)new;
 		break;
 	case 8: prev = *(u64 *)ptr;
-		if (prev == old)
+		if (prev == (u64)old)
 			*(u64 *)ptr = (u64)new;
 		break;
 	default:

--- a/include/linux/atomic.h
+++ b/include/linux/atomic.h
@@ -124,8 +124,8 @@ static inline void atomic_or(int i, atomic_t *v)
 }
 #endif /* #ifndef CONFIG_ARCH_HAS_ATOMIC_OR */
 
-#include <asm-generic/atomic-long.h>
 #ifdef CONFIG_GENERIC_ATOMIC64
 #include <asm-generic/atomic64.h>
 #endif
+#include <asm-generic/atomic-long.h>
 #endif /* _LINUX_ATOMIC_H */

--- a/include/linux/types.h
+++ b/include/linux/types.h
@@ -176,7 +176,7 @@ typedef struct {
 	int counter;
 } atomic_t;
 
-#ifdef CONFIG_64BIT
+#if defined(CONFIG_64BIT) && !defined(CONFIG_GENERIC_ATOMIC64)
 typedef struct {
 	long counter;
 } atomic64_t;


### PR DESCRIPTION
This branch contains changes outside arch/riscv/ that are necessary for RV64 without atomic instructions (CONFIG_RV_ATOMIC=n).