### PR TITLE
Linux 4.1.y dma

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,42 @@
-Linux/RISC-V
-================================================================================
+# Linux/RISC-V
 
 This is a port of Linux kernel for the [RISC-V](http://riscv.org/)
 instruction set architecture.
-Development is currently based on the [4.1 longterm branch](
-https://git.kernel.org/cgit/linux/kernel/git/stable/linux-stable.git/log/?h=linux-4.1.y).
+Development is currently based on the
+[4.1 longterm branch](https://git.kernel.org/cgit/linux/kernel/git/stable/linux-stable.git/log/?h=linux-4.1.y).
 
-Building the kernel image
---------------------------------------------------------------------------------
 
-1. Fetch upstream sources and overlay the `riscv` architecture-specific
-   subtree:
+## Obtaining kernel sources
 
-        $ curl -L https://cdn.kernel.org/pub/linux/kernel/v4.x/linux-4.1.15.tar.xz | tar -xJ
+### Master
+
+Overlay the `riscv` architecture-specific subtree onto an upstream release:
+
+        $ curl -L https://cdn.kernel.org/pub/linux/kernel/v4.x/linux-4.1.17.tar.xz | tar -xJ
         $ cd linux-4.1.15
         $ git init
-        $ git remote add origin https://github.com/riscv/riscv-linux.git
+        $ git remote add -t master origin https://github.com/riscv/riscv-linux.git
         $ git fetch
         $ git checkout -f -t origin/master
 
-1. Populate `./.config` with the default symbol values:
+Note that the `-t <branch>` option minimizes the history fetched.
+To add another branch:
+
+        $ git remote set-branches --add origin <branch>
+        $ git fetch
+
+### Full kernel source trees
+
+For convenience, full kernel source trees are maintained on separate
+branches tracking
+[linux-stable](https://git.kernel.org/cgit/linux/kernel/git/stable/linux-stable.git):
+
+* `linux-4.1.y-riscv`
+* `linux-3.14.y-riscv` (historical)
+
+## Building the kernel image
+
+1. Create kernel configuration based on architecture defaults:
 
         $ make ARCH=riscv defconfig
 
@@ -29,7 +46,7 @@ Building the kernel image
 
 1. Build the uncompressed kernel image:
 
-        $ make ARCH=riscv -j vmlinux
+        $ make -j4 ARCH=riscv vmlinux
 
 1. Boot the kernel in the functional simulator, optionally specifying a
    raw disk image for the root filesystem:
@@ -39,8 +56,7 @@ Building the kernel image
    `bbl` (the Berkeley Boot Loader) is available from the
    [riscv-pk](https://github.com/riscv/riscv-pk) repository.
 
-Exporting kernel headers
---------------------------------------------------------------------------------
+## Exporting kernel headers
 
 The `riscv-gnu-toolchain` repository includes a copy of the kernel header files.
 If the userspace API has changed, export the updated headers to the

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Development is currently based on the
 Overlay the `riscv` architecture-specific subtree onto an upstream release:
 
         $ curl -L https://cdn.kernel.org/pub/linux/kernel/v4.x/linux-4.1.17.tar.xz | tar -xJ
-        $ cd linux-4.1.15
+        $ cd linux-4.1.17
         $ git init
         $ git remote add -t master origin https://github.com/riscv/riscv-linux.git
         $ git fetch

--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -21,12 +21,14 @@ config RISCV
 	select RV_SYSRISCV_ATOMIC if !RV_ATOMIC
 	select SYSCTL_EXCEPTION_TRACE
 	select HAVE_ARCH_TRACEHOOK
+	select HAS_DMA
+	select HAVE_DMA_ATTRS
 
 config MMU
 	def_bool y
 
 config NO_DMA
-	def_bool y
+	def_bool n
 
 config STACKTRACE_SUPPORT
 	def_bool y

--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -145,9 +145,15 @@ endchoice
 
 config NR_IRQS
 	int "Number of IRQs"
-	default "2"
+	default "16"
 	help
 	  Maximum number of IRQs
+
+config NR_IRQS_CORE
+	int "Number of RISC-V core IRQs"
+	default "2"
+	help
+	  Number of IRQs connected to the CPU cores
 
 source "mm/Kconfig"
 

--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -143,6 +143,12 @@ config 64BIT
 
 endchoice
 
+config NR_IRQS
+	int "Number of IRQs"
+	default "2"
+	help
+	  Maximum number of IRQs
+
 source "mm/Kconfig"
 
 source "kernel/Kconfig.preempt"

--- a/arch/riscv/include/asm/dma-mapping.h
+++ b/arch/riscv/include/asm/dma-mapping.h
@@ -1,0 +1,168 @@
+#ifndef _ASM_RISCV_DMA_MAPPING_H
+#define _ASM_RISCV_DMA_MAPPING_H
+
+// adapted from arch/x86/include/asm/dma-mapping.h
+// by Jamey Hicks <jamey.hicks@gmail.com>
+
+/*
+ * IOMMU interface. See Documentation/DMA-API-HOWTO.txt and
+ * Documentation/DMA-API.txt for documentation.
+ */
+
+#include <linux/kmemcheck.h>
+#include <linux/scatterlist.h>
+#include <linux/dma-debug.h>
+#include <linux/dma-attrs.h>
+#include <asm/io.h>
+//#include <asm/swiotlb.h>
+#include <asm-generic/dma-coherent.h>
+#include <linux/dma-contiguous.h>
+
+#define DMA_ERROR_CODE	0
+
+extern struct dma_map_ops *dma_ops;
+
+static inline struct dma_map_ops *get_dma_ops(struct device *dev)
+{
+#ifndef CONFIG_RISCV_DEV_DMA_OPS
+	return dma_ops;
+#else
+	if (unlikely(!dev) || !dev->archdata.dma_ops)
+		return dma_ops;
+	else
+		return dev->archdata.dma_ops;
+#endif
+}
+
+#include <asm-generic/dma-mapping-common.h>
+
+/* Make sure we keep the same behaviour */
+static inline int dma_mapping_error(struct device *dev, dma_addr_t dma_addr)
+{
+	struct dma_map_ops *ops = get_dma_ops(dev);
+	debug_dma_mapping_error(dev, dma_addr);
+	if (ops->mapping_error)
+		return ops->mapping_error(dev, dma_addr);
+
+	return (dma_addr == DMA_ERROR_CODE);
+}
+
+#define dma_alloc_noncoherent(d, s, h, f) dma_alloc_coherent(d, s, h, f)
+#define dma_free_noncoherent(d, s, v, h) dma_free_coherent(d, s, v, h)
+
+extern int dma_supported(struct device *hwdev, u64 mask);
+extern int dma_set_mask(struct device *dev, u64 mask);
+
+extern void *dma_generic_alloc_coherent(struct device *dev, size_t size,
+					dma_addr_t *dma_addr, gfp_t flag,
+					struct dma_attrs *attrs);
+
+extern void dma_generic_free_coherent(struct device *dev, size_t size,
+				      void *vaddr, dma_addr_t dma_addr,
+				      struct dma_attrs *attrs);
+
+#ifdef CONFIG_RISCV_DMA_REMAP /* Platform code defines bridge-specific code */
+extern bool dma_capable(struct device *dev, dma_addr_t addr, size_t size);
+extern dma_addr_t phys_to_dma(struct device *dev, phys_addr_t paddr);
+extern phys_addr_t dma_to_phys(struct device *dev, dma_addr_t daddr);
+#else
+
+static inline bool dma_capable(struct device *dev, dma_addr_t addr, size_t size)
+{
+	if (!dev->dma_mask)
+		return 0;
+
+	return addr + size - 1 <= *dev->dma_mask;
+}
+
+static inline dma_addr_t phys_to_dma(struct device *dev, phys_addr_t paddr)
+{
+	return paddr;
+}
+
+static inline phys_addr_t dma_to_phys(struct device *dev, dma_addr_t daddr)
+{
+	return daddr;
+}
+#endif /* CONFIG_RISCV_DMA_REMAP */
+
+static inline void
+dma_cache_sync(struct device *dev, void *vaddr, size_t size,
+	enum dma_data_direction dir)
+{
+	flush_write_buffers();
+}
+
+static inline unsigned long dma_alloc_coherent_mask(struct device *dev,
+						    gfp_t gfp)
+{
+	unsigned long dma_mask = 0;
+
+	dma_mask = dev->coherent_dma_mask;
+	if (!dma_mask)
+		dma_mask = (gfp & GFP_DMA) ? DMA_BIT_MASK(24) : DMA_BIT_MASK(32);
+
+	return dma_mask;
+}
+
+static inline gfp_t dma_alloc_coherent_gfp_flags(struct device *dev, gfp_t gfp)
+{
+	unsigned long dma_mask = dma_alloc_coherent_mask(dev, gfp);
+
+	if (dma_mask <= DMA_BIT_MASK(24))
+		gfp |= GFP_DMA;
+#ifdef CONFIG_RISCV_64
+	if (dma_mask <= DMA_BIT_MASK(32) && !(gfp & GFP_DMA))
+		gfp |= GFP_DMA32;
+#endif
+       return gfp;
+}
+
+#define dma_alloc_coherent(d,s,h,f)	dma_alloc_attrs(d,s,h,f,NULL)
+
+static inline void *
+dma_alloc_attrs(struct device *dev, size_t size, dma_addr_t *dma_handle,
+		gfp_t gfp, struct dma_attrs *attrs)
+{
+	struct dma_map_ops *ops = get_dma_ops(dev);
+	void *memory;
+
+	gfp &= ~(__GFP_DMA | __GFP_HIGHMEM | __GFP_DMA32);
+
+	if (dma_alloc_from_coherent(dev, size, dma_handle, &memory))
+		return memory;
+
+	BUG_ON (!dev);
+
+	if (!is_device_dma_capable(dev))
+		return NULL;
+
+	if (!ops->alloc)
+		return NULL;
+
+	memory = ops->alloc(dev, size, dma_handle,
+			    dma_alloc_coherent_gfp_flags(dev, gfp), attrs);
+	debug_dma_alloc_coherent(dev, size, *dma_handle, memory);
+
+	return memory;
+}
+
+#define dma_free_coherent(d,s,c,h) dma_free_attrs(d,s,c,h,NULL)
+
+static inline void dma_free_attrs(struct device *dev, size_t size,
+				  void *vaddr, dma_addr_t bus,
+				  struct dma_attrs *attrs)
+{
+	struct dma_map_ops *ops = get_dma_ops(dev);
+
+	WARN_ON(irqs_disabled());       /* for portability */
+
+	if (dma_release_from_coherent(dev, get_order(size), vaddr))
+		return;
+
+	debug_dma_free_coherent(dev, size, vaddr, bus);
+	if (ops->free)
+		ops->free(dev, size, vaddr, bus, attrs);
+}
+
+#endif

--- a/arch/riscv/include/asm/dma-mapping.h
+++ b/arch/riscv/include/asm/dma-mapping.h
@@ -111,7 +111,7 @@ static inline gfp_t dma_alloc_coherent_gfp_flags(struct device *dev, gfp_t gfp)
 
 	if (dma_mask <= DMA_BIT_MASK(24))
 		gfp |= GFP_DMA;
-#ifdef CONFIG_RISCV_64
+#ifdef CONFIG_64BIT
 	if (dma_mask <= DMA_BIT_MASK(32) && !(gfp & GFP_DMA))
 		gfp |= GFP_DMA32;
 #endif

--- a/arch/riscv/include/asm/io.h
+++ b/arch/riscv/include/asm/io.h
@@ -56,6 +56,11 @@ extern void iounmap(void __iomem *addr);
 
 #endif /* CONFIG_MMU */
 
+static inline void flush_write_buffers(void)
+{
+  // sfence goes here?
+}
+
 #include <asm-generic/io.h>
 
 #endif /* __KERNEL__ */

--- a/arch/riscv/include/asm/io.h
+++ b/arch/riscv/include/asm/io.h
@@ -56,6 +56,8 @@ extern void iounmap(void __iomem *addr);
 
 #endif /* CONFIG_MMU */
 
+#include <asm-generic/io.h>
+
 #endif /* __KERNEL__ */
 
 #endif /* _ASM_RISCV_IO_H */

--- a/arch/riscv/include/asm/irq.h
+++ b/arch/riscv/include/asm/irq.h
@@ -1,7 +1,7 @@
 #ifndef _ASM_RISCV_IRQ_H
 #define _ASM_RISCV_IRQ_H
 
-#define NR_IRQS         2
+#define NR_IRQS         CONFIG_NR_IRQS
 #define IRQ_SOFTWARE    0
 #define IRQ_TIMER       1
 

--- a/arch/riscv/kernel/Makefile
+++ b/arch/riscv/kernel/Makefile
@@ -9,6 +9,7 @@ obj-y	:= cpu.o entry.o irq.o process.o ptrace.o reset.o setup.o \
 	   stacktrace.o vdso.o vdso/
 
 obj-$(CONFIG_EARLY_PRINTK)      += early_printk.o
+obj-$(CONFIG_HAS_DMA)           += dma-ops.o
 obj-$(CONFIG_SMP)		+= smpboot.o smp.o
 
 clean:

--- a/arch/riscv/kernel/dma-ops.c
+++ b/arch/riscv/kernel/dma-ops.c
@@ -1,0 +1,154 @@
+/* adapted from arch/x86/kernel/pci-nommu.c  by Jamey Hicks <jamey.hicks@gmail.com> */
+
+/* Fallback functions when the main IOMMU code is not compiled in. This
+   code is roughly equivalent to i386. */
+#include <linux/dma-mapping.h>
+#include <linux/scatterlist.h>
+#include <linux/string.h>
+#include <linux/gfp.h>
+#include <linux/pci.h>
+#include <linux/mm.h>
+
+//#include <asm/processor.h>
+//#include <asm/iommu.h>
+#include <asm/dma.h>
+
+// copied from arch/x86/kernel/pci-dma.c
+void *dma_generic_alloc_coherent(struct device *dev, size_t size,
+				 dma_addr_t *dma_addr, gfp_t flag,
+				 struct dma_attrs *attrs)
+{
+	unsigned long dma_mask;
+	struct page *page;
+	unsigned int count = PAGE_ALIGN(size) >> PAGE_SHIFT;
+	dma_addr_t addr;
+
+	dma_mask = dma_alloc_coherent_mask(dev, flag);
+
+	flag &= ~__GFP_ZERO;
+again:
+	page = NULL;
+	/* CMA can be used only in the context which permits sleeping */
+	if (flag & __GFP_WAIT) {
+		page = dma_alloc_from_contiguous(dev, count, get_order(size));
+		if (page && page_to_phys(page) + size > dma_mask) {
+			dma_release_from_contiguous(dev, page, count);
+			page = NULL;
+		}
+	}
+	/* fallback */
+	if (!page)
+		page = alloc_pages_node(dev_to_node(dev), flag, get_order(size));
+	if (!page)
+		return NULL;
+
+	addr = page_to_phys(page);
+	if (addr + size > dma_mask) {
+		__free_pages(page, get_order(size));
+
+		if (dma_mask < DMA_BIT_MASK(32) && !(flag & GFP_DMA)) {
+			flag = (flag & ~GFP_DMA32) | GFP_DMA;
+			goto again;
+		}
+
+		return NULL;
+	}
+	memset(page_address(page), 0, size);
+	*dma_addr = addr;
+	return page_address(page);
+}
+
+// copied from arch/x86/kernel/pci-dma.c
+void dma_generic_free_coherent(struct device *dev, size_t size, void *vaddr,
+			       dma_addr_t dma_addr, struct dma_attrs *attrs)
+{
+	unsigned int count = PAGE_ALIGN(size) >> PAGE_SHIFT;
+	struct page *page = virt_to_page(vaddr);
+
+	if (!dma_release_from_contiguous(dev, page, count))
+		free_pages((unsigned long)vaddr, get_order(size));
+}
+
+static int
+check_addr(char *name, struct device *hwdev, dma_addr_t bus, size_t size)
+{
+	return 1;
+}
+
+static dma_addr_t no_iommu_map_page(struct device *dev, struct page *page,
+				 unsigned long offset, size_t size,
+				 enum dma_data_direction dir,
+				 struct dma_attrs *attrs)
+{
+	dma_addr_t bus = page_to_phys(page) + offset;
+	WARN_ON(size == 0);
+	if (!check_addr("map_single", dev, bus, size))
+		return DMA_ERROR_CODE;
+	flush_write_buffers();
+	return bus;
+}
+
+/* Map a set of buffers described by scatterlist in streaming
+ * mode for DMA.  This is the scatter-gather version of the
+ * above pci_map_single interface.  Here the scatter gather list
+ * elements are each tagged with the appropriate dma address
+ * and length.  They are obtained via sg_dma_{address,length}(SG).
+ *
+ * NOTE: An implementation may be able to use a smaller number of
+ *       DMA address/length pairs than there are SG table elements.
+ *       (for example via virtual mapping capabilities)
+ *       The routine returns the number of addr/length pairs actually
+ *       used, at most nents.
+ *
+ * Device ownership issues as mentioned above for pci_map_single are
+ * the same here.
+ */
+static int no_iommu_map_sg(struct device *hwdev, struct scatterlist *sg,
+			int nents, enum dma_data_direction dir,
+			struct dma_attrs *attrs)
+{
+	struct scatterlist *s;
+	int i;
+
+	WARN_ON(nents == 0 || sg[0].length == 0);
+
+	for_each_sg(sg, s, nents, i) {
+		BUG_ON(!sg_page(s));
+		s->dma_address = sg_phys(s);
+		if (!check_addr("map_sg", hwdev, s->dma_address, s->length))
+			return 0;
+#ifdef CONFIG_NEED_SG_DMA_LENGTH
+		s->dma_length = s->length;
+#endif
+	}
+	flush_write_buffers();
+	return nents;
+}
+
+static void no_iommu_sync_single_for_device(struct device *dev,
+			dma_addr_t addr, size_t size,
+			enum dma_data_direction dir)
+{
+	flush_write_buffers();
+}
+
+
+static void no_iommu_sync_sg_for_device(struct device *dev,
+			struct scatterlist *sg, int nelems,
+			enum dma_data_direction dir)
+{
+	flush_write_buffers();
+}
+
+struct dma_map_ops no_iommu_dma_ops = {
+	.alloc			= dma_generic_alloc_coherent,
+	.free			= dma_generic_free_coherent,
+	.map_sg			= no_iommu_map_sg,
+	.map_page		= no_iommu_map_page,
+	.sync_single_for_device = no_iommu_sync_single_for_device,
+	.sync_sg_for_device	= no_iommu_sync_sg_for_device,
+	.is_phys		= 1,
+};
+
+struct dma_map_ops *dma_ops = &no_iommu_dma_ops;
+EXPORT_SYMBOL(dma_ops);

--- a/arch/riscv/kernel/irq.c
+++ b/arch/riscv/kernel/irq.c
@@ -58,7 +58,7 @@ struct irq_chip riscv_irq_chip = {
 void __init init_IRQ(void)
 {
 	unsigned int irq;
-	for (irq = 0; irq < 2; irq++)
+	for (irq = 0; irq < CONFIG_NR_IRQS_CORE; irq++)
 	{
 		irq_set_chip_and_handler(irq, &riscv_irq_chip, handle_level_irq);
 	}

--- a/arch/riscv/kernel/irq.c
+++ b/arch/riscv/kernel/irq.c
@@ -58,7 +58,7 @@ struct irq_chip riscv_irq_chip = {
 void __init init_IRQ(void)
 {
 	unsigned int irq;
-	for (irq = 0; irq < NR_IRQS; irq++)
+	for (irq = 0; irq < 2; irq++)
 	{
 		irq_set_chip_and_handler(irq, &riscv_irq_chip, handle_level_irq);
 	}


### PR DESCRIPTION
These changes add RISC-V support for dma-mapping, enabling use of device drivers depending on these capabilities.
 