### PR TITLE
Earlycon mmio

### DIFF
--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -10,6 +10,7 @@ config RISCV
 	select CLONE_BACKWARDS
 	select GENERIC_CLOCKEVENTS
 	select GENERIC_CPU_DEVICES
+	select GENERIC_EARLY_IOREMAP
 	select GENERIC_IRQ_SHOW
 	select GENERIC_STRNCPY_FROM_USER
 	select GENERIC_STRNLEN_USER
@@ -57,6 +58,9 @@ config PGTABLE_LEVELS
 	int
 	default 3 if 64BIT
 	default 2
+
+config FIX_EARLYCON_MEM
+	def_bool y
 
 menu "Platform type"
 

--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -106,6 +106,9 @@ config CPU_SUPPORTS_64BIT_KERNEL
 config SBI_CONSOLE
 	tristate "SBI console support"
 	select TTY
+	select SERIAL_CORE
+	select SERIAL_CORE_CONSOLE
+	select SERIAL_EARLYCON
 	default y
 
 config RVC

--- a/arch/riscv/include/asm/Kbuild
+++ b/arch/riscv/include/asm/Kbuild
@@ -5,6 +5,7 @@ generic-y += cputime.h
 generic-y += device.h
 generic-y += div64.h
 generic-y += dma.h
+generic-y += early_ioremap.h
 generic-y += emergency-restart.h
 generic-y += errno.h
 generic-y += exec.h

--- a/arch/riscv/include/asm/fixmap.h
+++ b/arch/riscv/include/asm/fixmap.h
@@ -1,0 +1,67 @@
+/*
+ * fixmap.h: compile-time virtual memory allocation
+ *
+ * Adapted from arch/arm64 version.
+ */
+
+#ifndef _ASM_RISCV_FIXMAP_H
+#define _ASM_RISCV_FIXMAP_H
+
+#ifndef __ASSEMBLY__
+#include <linux/kernel.h>
+#include <linux/sizes.h>
+#include <asm/page.h>
+#include <asm/pgtable.h>
+
+/*
+ * Here we define all the compile-time 'special' virtual
+ * addresses. The point is to have a constant address at
+ * compile time, but to set the physical address only
+ * in the boot process.
+ *
+ * These 'compile-time allocated' memory buffers are
+ * page-sized. Use set_fixmap(idx,phys) to associate
+ * physical memory with fixmap indices.
+ *
+ * __end_of_fixed_addresses should not exceed (2MB / 4KB)
+ * because we use one pmd, only.
+ */
+enum fixed_addresses {
+	FIX_HOLE,
+
+	FIX_EARLYCON_MEM_BASE,
+	__end_of_permanent_fixed_addresses,
+
+	/*
+	 * Temporary boot-time mappings, used by early_ioremap(),
+	 * before ioremap() is functional.
+	 */
+#define NR_FIX_BTMAPS		(SZ_256K / PAGE_SIZE)
+#define FIX_BTMAPS_SLOTS	7
+#define TOTAL_FIX_BTMAPS	(NR_FIX_BTMAPS * FIX_BTMAPS_SLOTS)
+
+	FIX_BTMAP_END = __end_of_permanent_fixed_addresses,
+	FIX_BTMAP_BEGIN = FIX_BTMAP_END + TOTAL_FIX_BTMAPS - 1,
+
+	__end_of_fixed_addresses
+};
+
+#define FIXADDR_SIZE	(__end_of_permanent_fixed_addresses << PAGE_SHIFT)
+#define FIXADDR_TOP	(ALIGN(VMALLOC_START - SZ_4M, SZ_4M))
+#define FIXADDR_START	(FIXADDR_TOP - FIXADDR_SIZE)
+
+#define FIXMAP_PAGE_IO	PAGE_KERNEL
+
+void __init early_fixmap_init(void);
+
+#define __early_set_fixmap __set_fixmap
+
+#define __late_set_fixmap __set_fixmap
+#define __late_clear_fixmap(idx) __set_fixmap((idx), 0, FIXMAP_PAGE_CLEAR)
+
+extern void __set_fixmap(enum fixed_addresses idx, phys_addr_t phys, pgprot_t prot);
+
+#include <asm-generic/fixmap.h>
+
+#endif /* !__ASSEMBLY__ */
+#endif /* _ASM_RISCV_FIXMAP_H */

--- a/arch/riscv/include/asm/pgtable.h
+++ b/arch/riscv/include/asm/pgtable.h
@@ -319,7 +319,7 @@ static inline void pgtable_cache_init(void)
 #ifdef CONFIG_64BIT
 #define TASK_SIZE (PGDIR_SIZE * PTRS_PER_PGD / 2)
 #else
-#define TASK_SIZE VMALLOC_START
+#define TASK_SIZE (ALIGN(FIXADDR_START - SZ_4M, SZ_4M))
 #endif
 
 #include <asm-generic/pgtable.h>

--- a/arch/riscv/kernel/irq.c
+++ b/arch/riscv/kernel/irq.c
@@ -25,9 +25,11 @@ static void riscv_software_interrupt(void)
 		return;
 #endif
 
+#ifdef CONFIG_SBI_CONSOLE
 	ret = sbi_console_isr();
 	if (ret != IRQ_NONE)
 		return;
+#endif
 
 	BUG();
 }

--- a/arch/riscv/mm/ioremap.c
+++ b/arch/riscv/mm/ioremap.c
@@ -4,6 +4,7 @@
 #include <linux/io.h>
 
 #include <asm/pgtable.h>
+#include <asm/early_ioremap.h>
 
 /*
  * Remap an arbitrary physical address space into the kernel virtual
@@ -79,3 +80,7 @@ void iounmap(void __iomem *addr)
 }
 EXPORT_SYMBOL(iounmap);
 
+void __init early_ioremap_init(void)
+{
+	early_ioremap_setup();
+}


### PR DESCRIPTION
Hi.

I add some code that enable fixed-mapping to use ioremap function before kernel mm subsystem is initialized.
It is useful to output early-printk into mmio-based UART device.

please, review this code with commit log.
