### PR TITLE
support CONFIG_RV_PUM in the sstatus while process is started

### DIFF
--- a/arch/riscv/kernel/process.c
+++ b/arch/riscv/kernel/process.c
@@ -53,7 +53,11 @@ void show_regs(struct pt_regs *regs)
 void start_thread(struct pt_regs *regs, unsigned long pc, 
 	unsigned long sp)
 {
+	#ifdef CONFIG_RV_PUM
+	regs->sstatus = SR_PIE /* User mode, irqs on */ | SR_FS_INITIAL | SR_PUM;
+	#else
 	regs->sstatus = SR_PIE /* User mode, irqs on */ | SR_FS_INITIAL;
+	#endif
 	regs->sepc = pc;
 	regs->sp = sp;
 	set_fs(USER_DS);


### PR DESCRIPTION
if CONFIG_RV_PUM is set, the origin sstatus of process should have SR_PUM, other wise the PUM function will not  take effect