### PR TITLE
Update process.c

### DIFF
--- a/arch/riscv/kernel/process.c
+++ b/arch/riscv/kernel/process.c
@@ -53,7 +53,12 @@ void show_regs(struct pt_regs *regs)
 void start_thread(struct pt_regs *regs, unsigned long pc, 
 	unsigned long sp)
 {
+	
+	#ifdef CONFIG_RV_PUM
+	regs->sstatus = SR_PIE /* User mode, irqs on */ | SR_FS_INITIAL | SR_PUM;  /* support SR_PUM from the start of thread */ 
+	#else
 	regs->sstatus = SR_PIE /* User mode, irqs on */ | SR_FS_INITIAL;
+	#endif
 	regs->sepc = pc;
 	regs->sp = sp;
 	set_fs(USER_DS);


### PR DESCRIPTION
Add a support to CONFIG_RV_PUM, not only in the initial statage of the riscv hart, but also in the start_thread function, so the user level process can be protected from kernel access.