### PR TITLE
Patch 5

### DIFF
--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -144,6 +144,14 @@ config RV_PUM
 	  and kernel size increase if this is enabled.
 
 	  If unsure, say Y.
+	  
+config RV_NO_EXEC_BIT
+         def_bool y
+         prompt "Execute bit not used in the data and stack Memory" if EXPERT
+         ---help---
+           Protect User data and stack Memory from executing after loaded by the kernel, protect the user process from code inject    ion attacks.  There is no performance cost.
+ 
+           If unsure, say Y.
 
 endmenu
 

--- a/arch/riscv/include/asm/page.h
+++ b/arch/riscv/include/asm/page.h
@@ -106,8 +106,13 @@ extern unsigned long min_low_pfn;
 
 #endif /* __KERNEL__ */
 
+#ifdef CONFIG_RV_NO_EXEC_BIT
+#define VM_DATA_DEFAULT_FLAGS   (VM_READ | VM_WRITE | \
+                                   VM_MAYREAD | VM_MAYWRITE | VM_MAYEXEC)
+#else
 #define VM_DATA_DEFAULT_FLAGS	(VM_READ | VM_WRITE | VM_EXEC | \
 				 VM_MAYREAD | VM_MAYWRITE | VM_MAYEXEC)
+#endif
 
 #include <asm-generic/memory_model.h>
 #include <asm-generic/getorder.h>


### PR DESCRIPTION
Add config RV_NO_EXEC_BIT. This config will clear the X bit in the page table entry for data and stack memory, while the kernel loading the application to the memory .  So the  corresponding process can be protected from code injection attacks.