### PR TITLE
Update page.h

### DIFF
--- a/arch/riscv/include/asm/page.h
+++ b/arch/riscv/include/asm/page.h
@@ -106,7 +106,7 @@ extern unsigned long min_low_pfn;
 
 #endif /* __KERNEL__ */
 
-#define VM_DATA_DEFAULT_FLAGS	(VM_READ | VM_WRITE | VM_EXEC | \
+#define VM_DATA_DEFAULT_FLAGS	(VM_READ | VM_WRITE | \
 				 VM_MAYREAD | VM_MAYWRITE | VM_MAYEXEC)
 
 #include <asm-generic/memory_model.h>


### PR DESCRIPTION
remove VM_EXEC from VM_DATA_DEFAULT_FLAGS, for security of data and stack. This modification will not affect application execution, will protect the user application from code injection attacks.