### PR TITLE
Fix null pointer dereference on unimplemented syscalls

### DIFF
--- a/arch/riscv/kernel/syscall_table.c
+++ b/arch/riscv/kernel/syscall_table.c
@@ -21,5 +21,6 @@
 #define __SYSCALL(nr, call) [nr] = (call),
 
 void *sys_call_table[__NR_syscalls] = {
+	[0 ... __NR_syscalls - 1] = sys_ni_syscall,
 #include <asm/unistd.h>
 };


### PR DESCRIPTION
Return -ENOSYS instead.