### PR TITLE
riscv,mm,init: fix wrong zone size

### DIFF
--- a/arch/riscv/mm/init.c
+++ b/arch/riscv/mm/init.c
@@ -28,7 +28,7 @@ static void __init zone_sizes_init(void)
 {
 	unsigned long zones_size[MAX_NR_ZONES];
 	memset(zones_size, 0, sizeof(zones_size));
-	zones_size[ZONE_NORMAL] = pfn_base + max_mapnr;
+	zones_size[ZONE_NORMAL] = max_mapnr;
 	free_area_init_node(0, zones_size, pfn_base, NULL);
 }
 


### PR DESCRIPTION
* pfn_base should not be added to zone size, else it will lead to wrong
  total page number. With 16MB physical memory, it will require 32MB
  memory to store node_mem_map. This will eventually trigger an illegal
  memory accessing during memory initialization.