### PR TITLE
Explicitly store FP state in struct sigcontext

### DIFF
--- a/arch/riscv/include/asm/Kbuild
+++ b/arch/riscv/include/asm/Kbuild
@@ -52,7 +52,6 @@ generic-y += termios.h
 generic-y += topology.h
 generic-y += trace_clock.h
 generic-y += types.h
-generic-y += ucontext.h
 generic-y += unaligned.h
 generic-y += user.h
 generic-y += vga.h

--- a/arch/riscv/include/uapi/asm/Kbuild
+++ b/arch/riscv/include/uapi/asm/Kbuild
@@ -1,10 +1,4 @@
 # UAPI Header export list
 include include/uapi/asm-generic/Kbuild.asm
 
-header-y += auxvec.h
-header-y += bitsperlong.h
-header-y += byteorder.h
-header-y += ptrace.h
-header-y += sigcontext.h
-header-y += siginfo.h
-header-y += unistd.h
+generic-y += setup.h

--- a/arch/riscv/include/uapi/asm/elf.h
+++ b/arch/riscv/include/uapi/asm/elf.h
@@ -19,7 +19,7 @@ typedef unsigned long elf_greg_t;
 typedef struct user_regs_struct elf_gregset_t;
 #define ELF_NGREG (sizeof(elf_gregset_t) / sizeof(elf_greg_t))
 
-typedef struct __riscv_d_ext_state elf_fpregset_t;
+typedef union __riscv_fp_state elf_fpregset_t;
 
 #define ELF_RISCV_R_SYM(r_info) ((r_info) >> 32)
 #define ELF_RISCV_R_TYPE(r_info) ((r_info) & 0xffffffff)

--- a/arch/riscv/include/uapi/asm/ptrace.h
+++ b/arch/riscv/include/uapi/asm/ptrace.h
@@ -59,9 +59,28 @@ struct user_regs_struct {
 	unsigned long t6;
 };
 
+struct __riscv_f_ext_state {
+	__u32 f[32];
+	__u32 fcsr;
+};
+
 struct __riscv_d_ext_state {
 	__u64 f[32];
 	__u32 fcsr;
+};
+
+struct __riscv_q_ext_state {
+	__u64 f[64] __attribute__((aligned(16)));
+	__u32 fcsr;
+	/* Reserved for expansion of sigcontext structure.  Currently zeroed
+	 * upon signal, and must be zero upon sigreturn.  */
+	__u32 reserved[3];
+};
+
+union __riscv_fp_state {
+	struct __riscv_f_ext_state f;
+	struct __riscv_d_ext_state d;
+	struct __riscv_q_ext_state q;
 };
 
 #endif /* __ASSEMBLY__ */

--- a/arch/riscv/include/uapi/asm/sigcontext.h
+++ b/arch/riscv/include/uapi/asm/sigcontext.h
@@ -17,18 +17,6 @@
 
 #include <asm/ptrace.h>
 
-/* Extension context structure
- *
- * This extends the signal context below with architectural state for
- * an ISA extension.  The state extends from the end of this struct
- * to size bytes thereafter.  The tag identifies the extension type.
- */
-struct __riscv_ext_context {
-	struct __riscv_ext_context *next;
-	__u32 tag;
-	__u32 size;
-};
-
 /* Signal context structure
  *
  * This contains the context saved before a signal handler is invoked;
@@ -36,15 +24,7 @@ struct __riscv_ext_context {
  */
 struct sigcontext {
 	struct user_regs_struct sc_regs;
-	struct __riscv_ext_context *sc_ext;
-};
-
-/* Double-precision floating-point extension context */
-#define __riscv_d_ext_tag 0x00000003
-
-struct __riscv_d_ext_context {
-  struct __riscv_ext_context head;
-  struct __riscv_d_ext_state state;
+	union __riscv_fp_state sc_fpregs;
 };
 
 #endif /* _UAPI_ASM_RISCV_SIGCONTEXT_H */

--- a/arch/riscv/include/uapi/asm/ucontext.h
+++ b/arch/riscv/include/uapi/asm/ucontext.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2012 ARM Ltd.
+ * Copyright (C) 2017 SiFive, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * This file was copied from arch/arm64/include/uapi/asm/ucontext.h
+ */
+#ifndef _UAPI__ASM_UCONTEXT_H
+#define _UAPI__ASM_UCONTEXT_H
+
+#include <linux/types.h>
+
+struct ucontext {
+	unsigned long	  uc_flags;
+	struct ucontext	 *uc_link;
+	stack_t		  uc_stack;
+	sigset_t	  uc_sigmask;
+	/* glibc uses a 1024-bit sigset_t */
+	__u8		  __unused[1024 / 8 - sizeof(sigset_t)];
+	/* last for future expansion */
+	struct sigcontext uc_mcontext;
+};
+
+#endif /* _UAPI__ASM_UCONTEXT_H */


### PR DESCRIPTION
Size it to handle the Q extension.
Reserve 12 extra bytes for future extension state.