### PR TITLE
RISC-V: remove redundant select {32,64}BIT

### DIFF
--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -103,7 +103,6 @@ choice
 config ARCH_RV32I
 	bool "RV32I"
 	select CPU_SUPPORTS_32BIT_KERNEL
-	select 32BIT
 	select GENERIC_ASHLDI3
 	select GENERIC_ASHRDI3
 	select GENERIC_LSHRDI3
@@ -111,7 +110,6 @@ config ARCH_RV32I
 config ARCH_RV64I
 	bool "RV64I"
 	select CPU_SUPPORTS_64BIT_KERNEL
-	select 64BIT
 
 endchoice
 


### PR DESCRIPTION
32BIT depends on CPU_SUPPORTS_32BIT_KERNEL which is selected by ARCH_RV32I
so there is no need to explicitly select 32BIT in ARCH_RV32I.

The similar redundant select is present for 64BIT.

Signed-off-by: Antony Pavlov <antonynpavlov@gmail.com>