### PR TITLE
base: fix order of OF initialization

### DIFF
--- a/drivers/base/init.c
+++ b/drivers/base/init.c
@@ -31,9 +31,9 @@ void __init driver_init(void)
 	/* These are also core pieces, but must come after the
 	 * core core pieces.
 	 */
+	of_core_init();
 	platform_bus_init();
 	cpu_dev_init();
 	memory_dev_init();
 	container_dev_init();
-	of_core_init();
 }


### PR DESCRIPTION
This fixes: [    0.010000] cpu cpu0: Error -2 creating of_node link
... which you get for every CPU on all architectures with a OF cpu/ node.

This affects riscv, nios, etc.

Signed-off-by: Palmer Dabbelt <palmer@dabbelt.com>