### PR TITLE
pcie-xilinx: Depend on OF_PCI instead of the ARCH

### DIFF
--- a/drivers/pci/host/Kconfig
+++ b/drivers/pci/host/Kconfig
@@ -71,7 +71,7 @@ config PCI_HOST_GENERIC
 
 config PCIE_XILINX
 	bool "Xilinx AXI PCIe host bridge support"
-	depends on ARCH_ZYNQ || MICROBLAZE || (MIPS && PCI_DRIVERS_GENERIC)
+	depends on OF_PCI
 	help
 	  Say 'Y' here if you want kernel to support the Xilinx AXI PCIe
 	  Host Bridge driver.


### PR DESCRIPTION
There isn't a hard dependency of the Xilinx AXI-PCIe host bridge on any
architecture.  For example: at SiFive we map RISC-V cores to Xilinx
FPGAs and connect the Xilinx IP via a TileLink adapter, so the RISC-V
Linux port will need to be able to enable PCIE_XILINX in order to have
PCIe support.

This patch decouples the PCIE_XILINX support from ARCH.  Instead it just
depends on OF_PCI, which I believe is the only true dependency.

Signed-off-by: Palmer Dabbelt <palmer@dabbelt.com>