### PR TITLE
RISC-V: Remove unused CONFIG_HVC_RISCV_SBI code

### DIFF
--- a/arch/riscv/kernel/setup.c
+++ b/arch/riscv/kernel/setup.c
@@ -38,10 +38,6 @@
 #include <asm/tlbflush.h>
 #include <asm/thread_info.h>
 
-#ifdef CONFIG_HVC_RISCV_SBI
-#include <asm/hvc_riscv_sbi.h>
-#endif
-
 #ifdef CONFIG_DUMMY_CONSOLE
 struct screen_info screen_info = {
 	.orig_video_lines	= 30,
@@ -212,13 +208,6 @@ static void __init setup_bootmem(void)
 
 void __init setup_arch(char **cmdline_p)
 {
-#if defined(CONFIG_HVC_RISCV_SBI)
-	if (likely(early_console == NULL)) {
-		early_console = &riscv_sbi_early_console_dev;
-		register_console(early_console);
-	}
-#endif
-
 #ifdef CONFIG_CMDLINE_BOOL
 #ifdef CONFIG_CMDLINE_OVERRIDE
 	strlcpy(boot_command_line, builtin_cmdline, COMMAND_LINE_SIZE);


### PR DESCRIPTION
This is code that probably should never have made it into the kernel in
the first place: it depends on a driver that hadn't been reviewed yet.
During the HVC_SBI_RISCV review process a better way of doing this was
suggested, but that means this code is defunct.  It's compile-time
disabled in 4.15 because the driver isn't in, so I think it's safe to
just remove this for now.

CC: Greg KH <gregkh@linuxfoundation.org>
Signed-off-by: Palmer Dabbelt <palmer@sifive.com>