### PR TITLE
RISC-V: Logical vs Bitwise typo

### DIFF
--- a/arch/riscv/kernel/sys_riscv.c
+++ b/arch/riscv/kernel/sys_riscv.c
@@ -70,7 +70,7 @@ SYSCALL_DEFINE3(riscv_flush_icache, uintptr_t, start, uintptr_t, end,
 	bool local = (flags & SYS_RISCV_FLUSH_ICACHE_LOCAL) != 0;
 
 	/* Check the reserved flags. */
-	if (unlikely(flags & !SYS_RISCV_FLUSH_ICACHE_ALL))
+	if (unlikely(flags & ~SYS_RISCV_FLUSH_ICACHE_ALL))
 		return -EINVAL;
 
 	flush_icache_mm(mm, local);


### PR DESCRIPTION
In the current code, there is a ! logical NOT where a bitwise ~ NOT was
intended.  It means that we never return -EINVAL.

Signed-off-by: Dan Carpenter <dan.carpenter@oracle.com>
Signed-off-by: Palmer Dabbelt <palmer@sifive.com>