### PR TITLE
audit: Avoid build failures on systems without renameat

### DIFF
--- a/include/asm-generic/audit_dir_write.h
+++ b/include/asm-generic/audit_dir_write.h
@@ -27,7 +27,9 @@ __NR_mknod,
 __NR_mkdirat,
 __NR_mknodat,
 __NR_unlinkat,
+#ifdef __NR_renameat
 __NR_renameat,
+#endif
 __NR_linkat,
 __NR_symlinkat,
 #endif


### PR DESCRIPTION
renameat has been deprecated in favor of renameat2 for new ports.  This
allows the audit tests to build on RISC-V.

Reviewed-by: Christoph Hellwig <hch@lst.de>
Acked-by: Olof Johansson <olof@lixom.net>
Signed-off-by: Palmer Dabbelt <palmer@sifive.com>