### PR TITLE
Fix duplicate cmdline logic in riscv/kernel/setup.c and fdt.c

### DIFF
--- a/arch/riscv/kernel/setup.c
+++ b/arch/riscv/kernel/setup.c
@@ -235,11 +235,11 @@ static void __init setup_bootmem(void)
 
 void __init setup_arch(char **cmdline_p)
 {
-#if defined(CONFIG_EARLY_PRINTK)
-       if (likely(early_console == NULL)) {
-               early_console = &riscv_sbi_early_console_dev;
-               register_console(early_console);
-       }
+#if defined(CONFIG_HVC_RISCV_SBI) && defined(CONFIG_EARLY_PRINTK)
+	if (likely(early_console == NULL)) {
+		early_console = &riscv_sbi_early_console_dev;
+		register_console(early_console);
+	}
 #endif
 
 	*cmdline_p = boot_command_line;

--- a/arch/riscv/kernel/setup.c
+++ b/arch/riscv/kernel/setup.c
@@ -70,10 +70,6 @@ struct screen_info screen_info = {
 };
 #endif
 
-#ifdef CONFIG_CMDLINE_BOOL
-static char __initdata builtin_cmdline[COMMAND_LINE_SIZE] = CONFIG_CMDLINE;
-#endif /* CONFIG_CMDLINE_BOOL */
-
 unsigned long va_pa_offset;
 EXPORT_SYMBOL(va_pa_offset);
 unsigned long pfn_base;
@@ -246,18 +242,6 @@ void __init setup_arch(char **cmdline_p)
        }
 #endif
 
-#ifdef CONFIG_CMDLINE_BOOL
-#ifdef CONFIG_CMDLINE_OVERRIDE
-	strlcpy(boot_command_line, builtin_cmdline, COMMAND_LINE_SIZE);
-#else
-	if (builtin_cmdline[0] != '\0') {
-		/* Append bootloader command line to built-in */
-		strlcat(builtin_cmdline, " ", COMMAND_LINE_SIZE);
-		strlcat(builtin_cmdline, boot_command_line, COMMAND_LINE_SIZE);
-		strlcpy(boot_command_line, builtin_cmdline, COMMAND_LINE_SIZE);
-	}
-#endif /* CONFIG_CMDLINE_OVERRIDE */
-#endif /* CONFIG_CMDLINE_BOOL */
 	*cmdline_p = boot_command_line;
 
 	parse_early_param();


### PR DESCRIPTION
builtin_cmdline handling is present in drivers/of/fdt.c so the
duplicate logic in arch/riscv/setup.c results in duplication of
the builtin command line. e.g. CONFIG_CMDLINE="root=/dev/vda ro"
gets appended twice and gives "root=/dev/vda ro root=/dev/vda ro"

Before this patch:

[    0.000000] Kernel command line: root=/dev/vda ro root=/dev/vda ro

After this patch:

[    0.000000] Kernel command line: root=/dev/vda ro

Signed-off-by: Michael Clark <mjc@sifive.com>