### PR TITLE
Make provision for gdb debugging in kernel (VMA != LMA)

### DIFF
--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -52,6 +52,16 @@ config PAGE_OFFSET
 	default 0xffffffff80000000 if 64BIT && MAXPHYSMEM_2GB
 	default 0xffffffe000000000 if 64BIT && MAXPHYSMEM_128GB
 
+config LMA_OFFSET
+	prompt "Load Memory address offset"
+	hex
+	default 0x00000000
+        help
+          This selects the load memory address in the vmlinux kernel, which
+	  is needed if you want to do JTAG debugging on the kernel in gdb,
+	  with VM initially off. Default is 0 for compatibility but a more
+	  realistic value would be 0x80000000 for Rocket as an example.
+
 config STACKTRACE_SUPPORT
 	def_bool y
 

--- a/arch/riscv/kernel/vmlinux.lds.S
+++ b/arch/riscv/kernel/vmlinux.lds.S
@@ -12,7 +12,7 @@
  *   GNU General Public License for more details.
  */
 
-#define LOAD_OFFSET (PAGE_OFFSET-0x80000000)
+#define LOAD_OFFSET (PAGE_OFFSET-CONFIG_LMA_OFFSET)
 #include <asm/vmlinux.lds.h>
 #include <asm/page.h>
 #include <asm/cache.h>

--- a/arch/riscv/kernel/vmlinux.lds.S
+++ b/arch/riscv/kernel/vmlinux.lds.S
@@ -12,7 +12,7 @@
  *   GNU General Public License for more details.
  */
 
-#define LOAD_OFFSET PAGE_OFFSET
+#define LOAD_OFFSET (PAGE_OFFSET-0x80000000)
 #include <asm/vmlinux.lds.h>
 #include <asm/page.h>
 #include <asm/cache.h>
@@ -26,7 +26,7 @@ jiffies = jiffies_64;
 SECTIONS
 {
 	/* Beginning of code and text segment */
-	. = LOAD_OFFSET;
+	. = PAGE_OFFSET;
 	_start = .;
 	__init_begin = .;
 	HEAD_TEXT_SECTION


### PR DESCRIPTION
When vmlinux is created it expects to load at a virtual address high in memory, but a physical address of zero, this confuses gdb if you try to load the kernel using openocd/jtag, since most platforms do not have memory at a physical address of zero. This kernel config (LMA_OFFSET) allows loading into a physical memory address with virtual memory off (the normal case).  The default case is to give the same behaviour as before.