### PR TITLE
set_handle_irq: Return EBUSY if the handler has already been registered.

### DIFF
--- a/include/linux/irq.h
+++ b/include/linux/irq.h
@@ -1179,7 +1179,7 @@ int ipi_send_mask(unsigned int virq, const struct cpumask *dest);
  * Returns 0 on success, or -EBUSY if an IRQ handler has already been
  * registered.
  */
-void __init set_handle_irq(void (*handle_irq)(struct pt_regs *));
+int __init set_handle_irq(void (*handle_irq)(struct pt_regs *));
 
 /*
  * Allows interrupt handlers to find the irqchip that's been registered as the

--- a/kernel/irq/handle.c
+++ b/kernel/irq/handle.c
@@ -213,11 +213,12 @@ irqreturn_t handle_irq_event(struct irq_desc *desc)
 }
 
 #ifdef CONFIG_GENERIC_IRQ_MULTI_HANDLER
-void __init set_handle_irq(void (*handle_irq)(struct pt_regs *))
+int __init set_handle_irq(void (*handle_irq)(struct pt_regs *))
 {
 	if (handle_arch_irq)
-		return;
+		return -EBUSY;
 
 	handle_arch_irq = handle_irq;
+	return 0;
 }
 #endif


### PR DESCRIPTION
This is what's expected by the comments and at least by irq-riscv-intc.c

Signed-off-by: Shea Levy <shea@shealevy.com>