### PR TITLE
riscv: bugfix pointer error with pt_regs.

### DIFF
--- a/arch/riscv/kernel/ptrace.c
+++ b/arch/riscv/kernel/ptrace.c
@@ -47,11 +47,15 @@ static int riscv_gpr_set(struct task_struct *target,
 			 const void *kbuf, const void __user *ubuf)
 {
 	int ret;
-	struct pt_regs *regs;
+	struct user_regs_struct regs;
 
-	regs = task_pt_regs(target);
 	ret = user_regset_copyin(&pos, &count, &kbuf, &ubuf, &regs, 0, -1);
-	return ret;
+	if (ret)
+		return ret;
+
+	*(struct user_regs_struct *) task_pt_regs(target) = regs;
+
+	return 0;
 }
 
 


### PR DESCRIPTION
struct pt_regs *regs;
regs = task_pt_regs(target);
"regs" is the pointer of your pt_regs saved in your kernel stack and &reg will be pointer of pointer of your pt_regs.
This will break the kernel stack in user_regset_copyin.

You can ref the arch/arm/kernel/ptrace.c: gpr_set() about the issue.