### PR TITLE
sifive-serial: register uart port as console before adding it

### DIFF
--- a/drivers/tty/serial/sifive.c
+++ b/drivers/tty/serial/sifive.c
@@ -965,17 +965,18 @@ static int sifive_serial_probe(struct platform_device *pdev)
 		goto probe_out2;
 	}
 
+	sifive_serial_add_console_port(ssp);
+
 	r = uart_add_one_port(&sifive_serial_uart_driver, &ssp->port);
 	if (r != 0) {
 		dev_err(&pdev->dev, "could not add uart: %d\n", r);
 		goto probe_out3;
 	}
 
-	sifive_serial_add_console_port(ssp);
-
 	return 0;
 
 probe_out3:
+	sifive_serial_remove_console_port(ssp);
 	free_irq(ssp->port.irq, ssp);
 probe_out2:
 	clk_notifier_unregister(ssp->clk, &ssp->clk_notifier);


### PR DESCRIPTION
The console can be set up (by the kernel) as soon as `uart_add_one_port` is called. So we have to register the uart port as a console before that. Otherwise `sifive_serial_console_setup` fails and there is no console at all.

I have run into this problem (early console works fine but the normal console is never activated) with a single-core rocket (https://github.com/sifive/freedom/commit/cd9a525a662b9eaf27c14533159d723efcf4c184) including the UART running on an fpga with `console=ttySI0,115200` in the cmdline. With this patch, linux boots and runs fine, but I don't know much about the linux uart system, so take it with a grain of salt.