### PR TITLE
riscv: fix linking error in non-smp mode

### DIFF
--- a/arch/riscv/kernel/head.S
+++ b/arch/riscv/kernel/head.S
@@ -151,6 +151,7 @@ relocate:
 END(_start)
 
 .section .text
+#ifdef CONFIG_SMP
 .global boot_sec_cpu
 
 boot_sec_cpu:
@@ -161,6 +162,7 @@ boot_sec_cpu:
 	fence
 
 	tail smp_callin
+#endif
 
 __PAGE_ALIGNED_BSS
 	/* Empty zero page */


### PR DESCRIPTION
* `smp_callin` is only defined while smp is enabled